### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/olatunjiayodele2015/c80ed267-27e8-483c-a624-34cce475a8d5/2e2efe59-9d2a-4be4-a5b2-e10bffd7eb78/_apis/work/boardbadge/874c5a12-0157-4a6c-83ed-1c0ef729a615)](https://dev.azure.com/olatunjiayodele2015/c80ed267-27e8-483c-a624-34cce475a8d5/_boards/board/t/2e2efe59-9d2a-4be4-a5b2-e10bffd7eb78/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/olatunjiayodele2015/c80ed267-27e8-483c-a624-34cce475a8d5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.